### PR TITLE
Version 0.3.1

### DIFF
--- a/dist/styles.css
+++ b/dist/styles.css
@@ -560,6 +560,7 @@ img.favicon {
     align-items: center;
     color: var(--neutralSecondary);
     font-size: 14px;
+    user-select: none;
 }
 
 .info {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fluent-reader",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A simplistic, modern desktop RSS reader",
   "main": "./dist/electron.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,10 @@
       "output": "./bin/${platform}/${arch}/"
     },
     "win": {
-      "target": [ "nsis", "appx" ]
+      "target": [
+        "nsis",
+        "appx"
+      ]
     },
     "appx": {
       "applicationId": "FluentReader",
@@ -43,7 +46,9 @@
       "deleteAppDataOnUninstall": true
     },
     "mac": {
-      "target": [ "dmg" ]
+      "target": [
+        "dmg"
+      ]
     }
   },
   "devDependencies": {
@@ -55,17 +60,14 @@
     "@types/redux": "^3.6.0",
     "@types/redux-thunk": "^2.1.0",
     "@types/reselect": "^2.2.0",
-    "@yang991178/electron-proxy-agent": "^1.2.1",
     "@yang991178/rss-parser": "^3.8.1",
     "electron": "^9.0.4",
     "electron-builder": "^22.7.0",
     "electron-react-devtools": "^0.5.3",
     "electron-store": "^5.2.0",
     "electron-window-state": "^5.0.3",
-    "favicon": "0.0.2",
     "html-webpack-plugin": "^4.3.0",
     "nedb": "^1.8.0",
-    "pac-proxy-agent": "^4.1.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-intl-universal": "^2.2.5",
@@ -74,7 +76,6 @@
     "redux-devtools": "^3.5.0",
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0",
-    "simplebar-react": "^2.2.0",
     "ts-loader": "^7.0.4",
     "typescript": "^3.9.2",
     "webpack": "^4.43.0",

--- a/src/components/settings/app.tsx
+++ b/src/components/settings/app.tsx
@@ -164,6 +164,9 @@ class AppTab extends React.Component<AppTabProps, AppTabState> {
                             text={intl.get("app.setPac")} />
                     </Stack.Item>
                 </Stack>
+                <span className="settings-hint up">
+                    {intl.get("app.pacHint")}
+                </span>
             </form>}
 
             <Label>{intl.get("app.cleanup")}</Label>

--- a/src/electron.ts
+++ b/src/electron.ts
@@ -55,7 +55,26 @@ function createWindow() {
     mainWindow.loadFile((app.isPackaged ? "dist/" : "") + "index.html")
 }
 
-Menu.setApplicationMenu(null)
+if (process.platform === 'darwin') {
+    const template = [
+        {
+            label: "Application",
+            submenu: [
+                { label: "Quit", accelerator: "Command+Q", click: () => { app.quit() } }
+            ]
+        },
+        {
+            label: "Edit",
+            submenu: [
+                { label: "Copy", accelerator: "CmdOrCtrl+C", selector: "copy:" },
+                { label: "Paste", accelerator: "CmdOrCtrl+V", selector: "paste:" },
+            ]
+        }
+    ]
+    Menu.setApplicationMenu(Menu.buildFromTemplate(template))
+} else {
+    Menu.setApplicationMenu(null)
+}
 
 app.on("ready", createWindow)
 

--- a/src/electron.ts
+++ b/src/electron.ts
@@ -66,6 +66,9 @@ app.on("second-instance", () => {
 })
 
 app.on("window-all-closed", function () {
+    if (mainWindow) {
+        mainWindow.webContents.session.clearStorageData({ storages: ["cookies"] })
+    }
     mainWindow = null
     if (restarting) {
         init()

--- a/src/scripts/i18n/en-US.json
+++ b/src/scripts/i18n/en-US.json
@@ -141,6 +141,7 @@
         "enableProxy": "Enable Proxy",
         "badUrl": "Invalid URL",
         "pac": "PAC Address",
-        "setPac": "Set PAC"
+        "setPac": "Set PAC",
+        "pacHint": "For Socks proxies, it is recommended for PAC to return \"SOCKS5\" for proxy-side DNS. Turning off proxy requires restart."
     }
 }

--- a/src/scripts/i18n/zh-CN.json
+++ b/src/scripts/i18n/zh-CN.json
@@ -141,6 +141,7 @@
         "enableProxy": "启用代理",
         "badUrl": "请正确输入URL",
         "pac": "PAC地址",
-        "setPac": "设置PAC"
+        "setPac": "设置PAC",
+        "pacHint": "对于Socks代理建议PAC返回“SOCKS5”以启用代理端解析。关闭代理需重启应用后生效。"
     }
 }

--- a/src/scripts/models/item.ts
+++ b/src/scripts/models/item.ts
@@ -163,7 +163,7 @@ export function fetchItems(): AppThunk<Promise<void>> {
                     if (r.status === "fulfilled") items.push(...r.value)
                     else {
                         console.log(r.reason)
-                        dispatch(fetchItemsFailure(getState().sources[i], r.reason))
+                        dispatch(fetchItemsFailure(sources[i], r.reason))
                     }
                 })
                 insertItems(items)

--- a/src/scripts/settings.ts
+++ b/src/scripts/settings.ts
@@ -35,12 +35,11 @@ export function setProxy(address = null) {
     } else {
         store.set(PAC_STORE_KEY, address)
     }
-    remote.getCurrentWebContents().session.setProxy({
-        pacScript: getProxyStatus() ? address : ""
-    })
-    remote.session.fromPartition("sandbox").setProxy({
-        pacScript: getProxyStatus() ? address : ""
-    })
+    if (getProxyStatus()) {
+        let rules = { pacScript: address }
+        remote.getCurrentWebContents().session.setProxy(rules)
+        remote.session.fromPartition("sandbox").setProxy(rules)
+    }
 }
 
 const VIEW_STORE_KEY = "view"


### PR DESCRIPTION
### Features
- Use the Fetch API through Chromium instead of relying on Node. Improved the overall performance of the app. However, some users will have to reconfigure their PAC to use SOCKS5 instead of SOCKS to enable proxy-side DNS. See [Chromium's guide to proxy](https://chromium.googlesource.com/chromium/src/+/HEAD/net/docs/proxy.md).
- Better favicon support. 

### Bug fixes
- macOS users can now copy and paste in the app.
- Fixed an issue where system proxy settings are ignored when PAC is off (#3).