### PR TITLE
#56 update search : not case sensitive anymore

### DIFF
--- a/src/scripts/models/feed.ts
+++ b/src/scripts/models/feed.ts
@@ -36,7 +36,7 @@ export class FeedFilter {
         if (type & FilterType.ShowNotStarred) delete query.starred
         if (type & FilterType.ShowHidden) delete query.hidden
         if (filter.search !== "") {
-            let regex = RegExp(filter.search)
+            let regex = RegExp(filter.search, 'i')
             if (type & FilterType.FullSearch) {
                 query.$or = [
                     { title: { $regex: regex } },


### PR DESCRIPTION
_Note : I am a junior dev, humbly trying to help while keeping the codebase clean and beautiful. 🌸_

This PR follows the [feature requested #56](https://github.com/yang991178/fluent-reader/issues/56) by @tannersteele.

**Before:** 
Search functionality was case senstive.

**What my PR does:** 
Search functionality is not case sensitive anymore.

**How:** 
Adding the flag _i_ to the regex filter when searching.

**Problem:** 
I did not found how to colorize searched element on filtered feeds.
I'd be glad to help more with just a hint on where to look at! 😊

**Preview:**
_searching "codeur" (pardon my french)_
<img width="622" alt="Capture d’écran 2020-08-06 à 16 35 45" src="https://user-images.githubusercontent.com/32717624/89545976-52de7180-d804-11ea-8e20-c23c48ebf40f.png">

_searching "Codeur"_
<img width="635" alt="Capture d’écran 2020-08-06 à 16 36 02" src="https://user-images.githubusercontent.com/32717624/89545993-57a32580-d804-11ea-967c-8694ca83da88.png">
