### PR TITLE
Fix duplicated icon on Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,10 @@
         "AppImage"
       ],
       "icon": "build/icons",
-      "category": "Utility"
+      "category": "Utility",
+      "desktop": {
+        "StartupWMClass": "fluent-reader"
+      }
     }
   },
   "devDependencies": {


### PR DESCRIPTION
The generated `StartupWMClass` in the desktop entry was `Fluent Reader` which doesn't match the application id `fluent-reader`, resulting in duplicated icons (one for the desktop entry and another for the running app).