### PR TITLE
Add unpacked target for flatpak packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "package-mas": "sudo CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --mac mas",
     "package-mas-arm": "sudo CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --mac mas:arm64",
     "package-mas-sign": "node build/buildUniversalPkg.js && sudo vim \"bin/Fluent Reader.app/Contents/Info.plist\" && sudo bash build/resignAndPackage.sh",
-    "package-linux": "electron-builder --linux -p never"
+    "package-linux": "electron-builder --linux -p never",
+    "package-linux-unpacked": "electron-builder --dir -p never"
   },
   "keywords": [],
   "author": "Haoyuan Liu",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
         "AppImage"
       ],
       "icon": "build/icons",
-      "category": "Utility",
+      "category": "Network;Feed;",
       "desktop": {
         "StartupWMClass": "fluent-reader"
       }


### PR DESCRIPTION
Flatpak packaging needs only unpacked files and prohibits downloading anything during the compilation (npm dependencies are preloaded by Flatpak builder.) It's also unnecessary to generate an Appimage when targeting Flatpak. So this patch provides a way to only generate unpacked file for Linux.