### PR TITLE
Feed item date fallback

### DIFF
--- a/src/scripts/models/item.ts
+++ b/src/scripts/models/item.ts
@@ -34,7 +34,7 @@ export class RSSItem {
         this.title = item.title || intl.get("article.untitled")
         this.link = item.link || ""
         this.fetchedDate = new Date()
-        this.date = item.isoDate ? new Date(item.isoDate) : this.fetchedDate
+        this.date = new Date(item.isoDate ?? item.pubDate ?? this.fetchedDate)
         this.creator = item.creator
         this.hasRead = false
         this.starred = false


### PR DESCRIPTION
Most feeds provide either pubDate or isoDate, but few both. This patch gives more opportunities to fallback to the date specified by the feed, rather than only rely on `isoDate` and easily fallback to `fetchedData` (which is not quite related)

Closes #123