### PR TITLE
allow content to fallback to snippet

### DIFF
--- a/src/components/article.tsx
+++ b/src/components/article.tsx
@@ -227,7 +227,7 @@ class Article extends React.Component<ArticleProps, ArticleState> {
     }
 
     articleView = () => {
-        const a = encodeURIComponent(this.state.loadFull ? this.state.fullContent : this.props.item.content)
+        const a = encodeURIComponent(this.state.loadFull ? this.state.fullContent : this.props.item.content || this.props.item.snippet)
         const h = encodeURIComponent(renderToString(<>
             <p className="title">{this.props.item.title}</p>
             <p className="date">{this.props.item.date.toLocaleString(this.props.locale, {hour12: !this.props.locale.startsWith("zh")})}</p>


### PR DESCRIPTION
Some feeds only have `summary` but no `content`. However, according to the RSS 2.0 spec, it's totally valid. Fluent Reader should better the situation by falling back to snippet if no content