### PR TITLE
Added j/k navigation between adjacent articles

### DIFF
--- a/src/components/article.tsx
+++ b/src/components/article.tsx
@@ -221,6 +221,10 @@ class Article extends React.Component<ArticleProps, ArticleState> {
                 case "ArrowRight":
                     this.props.offsetItem(input.key === "ArrowLeft" ? -1 : 1)
                     break
+                case "k":
+                case "j":
+                    this.props.offsetItem(input.key === "j" ? -1 : 1)
+                    break
                 case "l":
                 case "L":
                     this.toggleWebpage()


### PR DESCRIPTION
Once the article has been opened, `j` will open the next article, and `k` will open the previous article