### PR TITLE
fix: prevent source duplication

### DIFF
--- a/src/components/settings/sources.tsx
+++ b/src/components/settings/sources.tsx
@@ -204,7 +204,9 @@ class SourcesTab extends React.Component<SourcesTabProps, SourcesTabState> {
 
     addSource = (event: React.FormEvent) => {
         event.preventDefault()
-        let trimmed = this.state.newUrl.trim()
+        
+        // Remove whitespace and trailing slash
+        const trimmed = this.state.newUrl.trim().replace(/\/$/, '')
         if (urlTest(trimmed)) this.props.addSource(trimmed)
     }
 


### PR DESCRIPTION
The app is currently treating URL with a trailing slash and URL without a trailing slash as different sources, and this can cause duplication.

I'm fixing the issue by finding and removing the trailing slash before the `addSource` operation is executed.

Tested locally with the following URLs:
- `https://stackoverflow.blog/feed`
- `https://stackoverflow.blog/feed/`