### PR TITLE
Add a toggle to allow opening new pages within the built-in browser and saving cookies.

### DIFF
--- a/src/bridges/settings.ts
+++ b/src/bridges/settings.ts
@@ -23,6 +23,13 @@ const settingsBridge = {
         ipcRenderer.invoke("set-menu", state)
     },
 
+    getWebViewOpenUrlStatus: (): boolean => {
+        return ipcRenderer.sendSync("get-webview-open-url-status")
+    },
+    toggleWebViewOpenUrlStatus: () => {
+        ipcRenderer.send("toggle-webview-open-url-status")
+    },
+    
     getProxyStatus: (): boolean => {
         return ipcRenderer.sendSync("get-proxy-status")
     },

--- a/src/components/article.tsx
+++ b/src/components/article.tsx
@@ -212,6 +212,10 @@ class Article extends React.Component<ArticleProps, ArticleState> {
     }
 
     keyDownHandler = (input: Electron.Input) => {
+        if (this.state.loadWebpage) {
+            // 内置网页中禁止快捷键以防影响网页登录之类功能，
+            return;
+        }
         if (input.type === "keyDown") {
             switch (input.key) {
                 case "Escape":

--- a/src/components/settings/app.tsx
+++ b/src/components/settings/app.tsx
@@ -34,6 +34,7 @@ type AppTabProps = {
 }
 
 type AppTabState = {
+    webViewOpenUrlStatus: boolean
     pacStatus: boolean
     pacUrl: string
     themeSettings: ThemeSettings
@@ -46,6 +47,7 @@ class AppTab extends React.Component<AppTabProps, AppTabState> {
     constructor(props) {
         super(props)
         this.state = {
+            webViewOpenUrlStatus: window.settings.getWebViewOpenUrlStatus(),
             pacStatus: window.settings.getProxyStatus(),
             pacUrl: window.settings.getProxy(),
             themeSettings: getThemeSettings(),
@@ -148,6 +150,13 @@ class AppTab extends React.Component<AppTabProps, AppTabState> {
         { key: "zh-TW", text: "中文（繁體）" },
     ]
 
+    toggleWebViewOpenUrlStatus = () => {
+        window.settings.toggleWebViewOpenUrlStatus()
+        this.setState({
+            webViewOpenUrlStatus: window.settings.getWebViewOpenUrlStatus(),
+        })
+    }
+
     toggleStatus = () => {
         window.settings.toggleProxyStatus()
         this.setState({
@@ -216,6 +225,18 @@ class AppTab extends React.Component<AppTabProps, AppTabState> {
                         options={this.searchEngineOptions()}
                         onChanged={this.onSearchEngineChanged}
                         style={{ width: 200 }}
+                    />
+                </Stack.Item>
+            </Stack>
+
+            <Stack horizontal verticalAlign="baseline">
+                <Stack.Item grow>
+                    <Label>{intl.get("app.enableWebViewOpenUrl")}</Label>
+                </Stack.Item>
+                <Stack.Item>
+                    <Toggle
+                        checked={this.state.webViewOpenUrlStatus}
+                        onChange={this.toggleWebViewOpenUrlStatus}
                     />
                 </Stack.Item>
             </Stack>

--- a/src/components/settings/app.tsx
+++ b/src/components/settings/app.tsx
@@ -240,6 +240,9 @@ class AppTab extends React.Component<AppTabProps, AppTabState> {
                     />
                 </Stack.Item>
             </Stack>
+            <span className="settings-hint up">
+                {intl.get("app.webViewOpenUrlHint")}
+            </span>
 
             <Stack horizontal verticalAlign="baseline">
                 <Stack.Item grow>

--- a/src/electron.ts
+++ b/src/electron.ts
@@ -1,8 +1,9 @@
 import { app, ipcMain, Menu, nativeTheme } from "electron"
 import { ThemeSettings, SchemaTypes } from "./schema-types"
-import { store } from "./main/settings"
+import { getWebViewOpenUrlStatus, store } from "./main/settings"
 import performUpdate from "./main/update-scripts"
 import { WindowManager } from "./main/window"
+import { saveCookies } from "./main/cookies"
 
 if (!process.mas) {
     const locked = app.requestSingleInstanceLock()
@@ -106,10 +107,12 @@ if (process.platform === "darwin") {
 const winManager = new WindowManager()
 
 app.on("window-all-closed", () => {
-    if (winManager.hasWindow()) {
-        winManager.mainWindow.webContents.session.clearStorageData({
-            storages: ["cookies", "localstorage"],
-        })
+    if (!getWebViewOpenUrlStatus()) {
+        if (winManager.hasWindow()) {
+            winManager.mainWindow.webContents.session.clearStorageData({
+                storages: ["cookies", "localstorage"],
+            })
+        }
     }
     winManager.mainWindow = null
     if (restarting) {

--- a/src/main/cookies.ts
+++ b/src/main/cookies.ts
@@ -1,0 +1,29 @@
+import Store = require("electron-store")
+import { getWebViewOpenUrlStatus } from "./settings"
+import { BrowserWindow, WebContents } from "electron"
+
+const cookieStore = new Store()
+const COOKIES_KEY = "cookiesKey"
+export async function saveCookies(webContents: WebContents) {
+    console.log('save cookie')
+    const currentSession = webContents.session
+    await currentSession.cookies.flushStore()
+    let cookies = await currentSession.cookies.get({})
+    let customCookies = cookies.map(cookie => ({
+        ...cookie,
+        url:(cookie.secure ? 'https://' : 'http://') + cookie.domain.replace(/^\./, '') + cookie.path
+    }))
+    console.log('save cookie: ' + JSON.stringify(customCookies))
+    cookieStore.set(COOKIES_KEY, customCookies)
+}
+export async function loadCookies(webContents: WebContents) {
+    const savedCookies = cookieStore.get(COOKIES_KEY)
+    cookieStore.get
+    console.log('load cookie: ' + JSON.stringify(savedCookies))
+    if (savedCookies && savedCookies.length > 0) {
+        const currentSession = webContents.session
+        savedCookies.forEach(cookie => {
+            currentSession.cookies.set(cookie)
+        })
+    }
+}

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -30,6 +30,20 @@ ipcMain.handle("set-menu", (_, state: boolean) => {
     store.set(MENU_STORE_KEY, state)
 })
 
+const WEBVIEW_OPEN_URL_STATUS_KEY = "webViewOpenUrlStatus"
+export function getWebViewOpenUrlStatus() {
+    return store.get(WEBVIEW_OPEN_URL_STATUS_KEY, false)
+}
+function toggleWebViewOpenUrlStatus() {
+    store.set(WEBVIEW_OPEN_URL_STATUS_KEY, !getWebViewOpenUrlStatus())
+}
+ipcMain.on("get-webview-open-url-status", event => {
+    event.returnValue = getWebViewOpenUrlStatus()
+})
+ipcMain.on("toggle-webview-open-url-status", () => {
+    toggleWebViewOpenUrlStatus()
+})
+
 const PAC_STORE_KEY = "pac"
 const PAC_STATUS_KEY = "pacOn"
 function getProxyStatus() {

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -4,6 +4,8 @@ import fs = require("fs")
 import { ImageCallbackTypes, TouchBarTexts } from "../schema-types"
 import { initMainTouchBar } from "./touchbar"
 import fontList = require("font-list")
+import settingsBridge from "../bridges/settings"
+import { getWebViewOpenUrlStatus } from "./settings"
 
 export function setUtilsListeners(manager: WindowManager) {
     async function openExternal(url: string, background = false) {
@@ -32,6 +34,11 @@ export function setUtilsListeners(manager: WindowManager) {
             }
         })
         contents.on("will-navigate", (event, url) => {
+            if (getWebViewOpenUrlStatus()) {
+                return;
+            }
+            event.preventDefault()
+            if (contents.getType() === "webview") openExternal(url)
         })
     })
 

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -6,6 +6,7 @@ import { initMainTouchBar } from "./touchbar"
 import fontList = require("font-list")
 import settingsBridge from "../bridges/settings"
 import { getWebViewOpenUrlStatus } from "./settings"
+import { loadCookies, saveCookies } from "./cookies"
 
 export function setUtilsListeners(manager: WindowManager) {
     async function openExternal(url: string, background = false) {
@@ -242,6 +243,12 @@ export function setUtilsListeners(manager: WindowManager) {
                     contents.send("webview-keydown", input)
                 }
             })
+            if (getWebViewOpenUrlStatus()) {
+                loadCookies(contents)
+                contents.on('did-finish-load', () => {
+                    saveCookies(contents)
+                })
+            }
         }
     })
 

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -32,8 +32,6 @@ export function setUtilsListeners(manager: WindowManager) {
             }
         })
         contents.on("will-navigate", (event, url) => {
-            event.preventDefault()
-            if (contents.getType() === "webview") openExternal(url)
         })
     })
 

--- a/src/schema-types.ts
+++ b/src/schema-types.ts
@@ -86,6 +86,7 @@ export type SchemaTypes = {
     theme: ThemeSettings
     pac: string
     pacOn: boolean
+    webViewOpenUrlStatus: boolean
     view: ViewType
     locale: string
     sourceGroups: SourceGroup[]

--- a/src/scripts/i18n/en-US.json
+++ b/src/scripts/i18n/en-US.json
@@ -232,6 +232,7 @@
         "lightTheme": "Light mode",
         "darkTheme": "Dark mode",
         "enableWebViewOpenUrl": "Enable WebView open url",
+        "webViewOpenUrlHint": "Enabling this switch will save cookies data for the built-in browser.",
         "enableProxy": "Enable Proxy",
         "badUrl": "Invalid URL",
         "pac": "PAC Address",

--- a/src/scripts/i18n/en-US.json
+++ b/src/scripts/i18n/en-US.json
@@ -231,6 +231,7 @@
         "theme": "Theme",
         "lightTheme": "Light mode",
         "darkTheme": "Dark mode",
+        "enableWebViewOpenUrl": "Enable WebView open url",
         "enableProxy": "Enable Proxy",
         "badUrl": "Invalid URL",
         "pac": "PAC Address",

--- a/src/scripts/i18n/zh-CN.json
+++ b/src/scripts/i18n/zh-CN.json
@@ -229,6 +229,7 @@
         "theme": "应用主题",
         "lightTheme": "浅色模式",
         "darkTheme": "深色模式",
+        "enableWebViewOpenUrl": "允许内置浏览器打开网页",
         "enableProxy": "启用代理",
         "badUrl": "请正确输入URL",
         "pac": "PAC地址",

--- a/src/scripts/i18n/zh-CN.json
+++ b/src/scripts/i18n/zh-CN.json
@@ -230,6 +230,7 @@
         "lightTheme": "浅色模式",
         "darkTheme": "深色模式",
         "enableWebViewOpenUrl": "允许内置浏览器打开网页",
+        "webViewOpenUrlHint": "开启后会保存内置浏览器的cookie数据。",
         "enableProxy": "启用代理",
         "badUrl": "请正确输入URL",
         "pac": "PAC地址",


### PR DESCRIPTION
主要处理需要登录或者有js防火墙的情况无法使用内置浏览器打开网页的问题，
默认还是一样，但在应用偏好中加了个开关，打开后就会在内置浏览器中直接打开新页面而不是弹出外部浏览器，
同时开启后会保存内置浏览器的cookies，以便记住登录状态，

Primarily addressed the issue where opening web pages in the built-in browser was restricted in cases requiring login or encountering JavaScript firewalls. The default behavior remains unchanged, but a new switch has been added to the application preferences. When toggled, new pages will open directly in the built-in browser instead of launching an external browser. Additionally, enabling this switch will preserve cookies in the built-in browser, ensuring the retention of login states.

Fixes #610 
Fixes #584 
Fixes #360 
Fixes #189 