### PR TITLE
Moved fetch call from rendering process to main process

### DIFF
--- a/src/bridges/utils.ts
+++ b/src/bridges/utils.ts
@@ -174,6 +174,10 @@ const utilsBridge = {
     initFontList: (): Promise<Array<string>> => {
         return ipcRenderer.invoke("init-font-list")
     },
+
+    fetchText: (url: string, isHtml: boolean = false) => {
+        return ipcRenderer.invoke("fetchText", url, isHtml)
+    }
 }
 
 declare global {

--- a/src/components/article.tsx
+++ b/src/components/article.tsx
@@ -18,7 +18,7 @@ import {
     SourceTextDirection,
 } from "../scripts/models/source"
 import { shareSubmenu } from "./context-menu"
-import { platformCtrl, decodeFetchResponse } from "../scripts/utils"
+import { platformCtrl } from "../scripts/utils"
 
 const FONT_SIZE_OPTIONS = [12, 13, 14, 15, 16, 17, 18, 19, 20]
 
@@ -330,9 +330,8 @@ class Article extends React.Component<ArticleProps, ArticleState> {
         this.setState({ fullContent: "", loaded: false, error: false })
         const link = this.props.item.link
         try {
-            const result = await fetch(link)
-            if (!result || !result.ok) throw new Error()
-            const html = await decodeFetchResponse(result, true)
+            const html = await window.utils.fetchText(link, true)
+            if (!html) throw new Error()
             if (link === this.props.item.link) {
                 this.setState({ fullContent: html })
             }

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -1,4 +1,4 @@
-import { ipcMain, shell, dialog, app, session, clipboard } from "electron"
+import { ipcMain, shell, dialog, app, session, clipboard, net } from "electron"
 import { WindowManager } from "./window"
 import fs = require("fs")
 import { ImageCallbackTypes, TouchBarTexts } from "../schema-types"
@@ -215,7 +215,7 @@ export function setUtilsListeners(manager: WindowManager) {
                             `new Promise(resolve => {
                         const dismiss = () => {
                             document.removeEventListener("mousedown", dismiss)
-                            document.removeEventListener("scroll", dismiss)                            
+                            document.removeEventListener("scroll", dismiss)
                             resolve()
                         }
                         document.addEventListener("mousedown", dismiss)
@@ -307,5 +307,13 @@ export function setUtilsListeners(manager: WindowManager) {
         return fontList.getFonts({
             disableQuoting: true,
         })
+    })
+
+    ipcMain.handle("fetchText", async (_, url, isHtml) => {
+        const response = await net.fetch(url)
+        if (response.status < 200 || response.status >= 300) {
+            throw new Error('Server error (' + response.status + ') ' + response.statusText)
+        }
+        return await response.text()
     })
 }


### PR DESCRIPTION
Using the fetch-function of the renderering function can lead to a 403 depending on the configuration of the server. Using the main process for the fetch solves this problem.