### PR TITLE
fix: compatible with miniflux

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src-elem 'self'; img-src *; style-src 'self' 'unsafe-inline'; font-src 'self' https://static2.sharepointonline.com; connect-src https: http:">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src-elem 'self'; img-src * data:; style-src 'self' 'unsafe-inline'; font-src 'self' https://static2.sharepointonline.com; connect-src https: http:">
     <title>Fluent Reader</title>
     <link rel="stylesheet" href="index.css">
   </head>

--- a/src/scripts/models/app.ts
+++ b/src/scripts/models/app.ts
@@ -7,7 +7,6 @@ import {
     DELETE_SOURCE,
     initSources,
     SourceOpenTarget,
-    updateFavicon,
 } from "./source"
 import { RSSItem, ItemActionTypes, FETCH_ITEMS, fetchItems } from "./item"
 import {
@@ -34,7 +33,7 @@ import {
 } from "./page"
 import { getCurrentLocale, setThemeDefaultFont } from "../settings"
 import locales from "../i18n/_locales"
-import { SYNC_SERVICE, ServiceActionTypes } from "./service"
+import { SYNC_SERVICE, ServiceActionTypes, updateFavicon } from "./service"
 
 export const enum ContextMenuType {
     Hidden,

--- a/src/scripts/models/services/miniflux.ts
+++ b/src/scripts/models/services/miniflux.ts
@@ -49,6 +49,12 @@ interface Entries {
     entries: Entry[]
 }
 
+interface IconEntity {
+    id: number
+    mime_type: string
+    data: string
+}
+
 const APIError = () => new Error(intl.get("service.failure"))
 
 // base endpoint, authorization with dedicated token or http basic user/pass pair
@@ -286,6 +292,29 @@ export const minifluxServiceHooks: ServiceHooks = {
             new Set(unread.map((entry: Entry) => String(entry.id))),
             new Set(starred.map((entry: Entry) => String(entry.id))),
         ]
+    },
+
+    fetchFavicon: (source: RSSSource) => async (_, getState) => {
+        const configs = getState().service as MinifluxConfigs
+        try {
+            let response = await fetchAPI(configs, `feeds/${source.serviceRef}/icon`)
+            if (response.ok) {
+                let iconEntity: IconEntity = await response.json()
+                if (iconEntity.data === undefined || iconEntity.data == null) {
+                    return null
+                }
+                if (iconEntity.data.length <= 0) {
+                    return null
+                }
+                if (!iconEntity.data.startsWith("image/")) {
+                    return null
+                }
+                return "data:" + iconEntity.data
+            }
+            return null
+        } catch {
+            return null
+        }
     },
 
     markRead: (item: RSSItem) => async (_, getState) => {

--- a/src/scripts/models/source.ts
+++ b/src/scripts/models/source.ts
@@ -20,6 +20,7 @@ import {
 import { saveSettings } from "./app"
 import { SourceRule } from "./rule"
 import { fixBrokenGroups } from "./group"
+import { updateFavicon } from "./service"
 
 export const enum SourceOpenTarget {
     Local,
@@ -412,35 +413,35 @@ export function toggleSourceHidden(source: RSSSource): AppThunk<Promise<void>> {
     }
 }
 
-export function updateFavicon(
-    sids?: number[],
-    force = false
-): AppThunk<Promise<void>> {
-    return async (dispatch, getState) => {
-        const initSources = getState().sources
-        if (!sids) {
-            sids = Object.values(initSources)
-                .filter(s => s.iconurl === undefined)
-                .map(s => s.sid)
-        } else {
-            sids = sids.filter(sid => sid in initSources)
-        }
-        const promises = sids.map(async sid => {
-            const url = initSources[sid].url
-            let favicon = (await fetchFavicon(url)) || ""
-            const source = getState().sources[sid]
-            if (
-                source &&
-                source.url === url &&
-                (force || source.iconurl === undefined)
-            ) {
-                source.iconurl = favicon
-                await dispatch(updateSource(source))
-            }
-        })
-        await Promise.all(promises)
-    }
-}
+// export function updateFavicon(
+//     sids?: number[],
+//     force = false
+// ): AppThunk<Promise<void>> {
+//     return async (dispatch, getState) => {
+//         const initSources = getState().sources
+//         if (!sids) {
+//             sids = Object.values(initSources)
+//                 .filter(s => s.iconurl === undefined)
+//                 .map(s => s.sid)
+//         } else {
+//             sids = sids.filter(sid => sid in initSources)
+//         }
+//         const promises = sids.map(async sid => {
+//             const url = initSources[sid].url
+//             let favicon = (await fetchFavicon(url)) || ""
+//             const source = getState().sources[sid]
+//             if (
+//                 source &&
+//                 source.url === url &&
+//                 (force || source.iconurl === undefined)
+//             ) {
+//                 source.iconurl = favicon
+//                 await dispatch(updateSource(source))
+//             }
+//         })
+//         await Promise.all(promises)
+//     }
+// }
 
 export function sourceReducer(
     state: SourceState = {},


### PR DESCRIPTION
fix: Use paging loading to avoid the unread value of the miniflux server being displayed as 100 after restarting (#641).
fix: Use the favicon provided by the miniflux server. (The solution here is to directly insert the base64 of the image into the database. It's not good. Maybe there is a better way?)
2 issues fixed here, please check.
