### PR TITLE
[FEATURE REQUEST] Add feed delay feature.

### DIFF
--- a/src/bridges/settings.ts
+++ b/src/bridges/settings.ts
@@ -89,6 +89,13 @@ const settingsBridge = {
         ipcRenderer.invoke("set-fetch-interval", interval)
     },
 
+    getFeedDelay: (): number => {
+        return ipcRenderer.sendSync("get-feed-delay")
+    },
+    setFeedDelay: (delay: number) => {
+        ipcRenderer.invoke("set-feed-delay", delay)
+    },
+
     getSearchEngine: (): SearchEngines => {
         return ipcRenderer.sendSync("get-search-engine")
     },

--- a/src/components/settings/app.tsx
+++ b/src/components/settings/app.tsx
@@ -29,6 +29,7 @@ import DangerButton from "../utils/danger-button"
 type AppTabProps = {
     setLanguage: (option: string) => void
     setFetchInterval: (interval: number) => void
+    setFeedDelay: (delay: number) => void
     deleteArticles: (days: number) => Promise<void>
     importAll: () => Promise<void>
 }
@@ -91,6 +92,19 @@ class AppTab extends React.Component<AppTabProps, AppTabState> {
     ]
     onFetchIntervalChanged = (item: IDropdownOption) => {
         this.props.setFetchInterval(item.key as number)
+    }
+
+    feedDelayOptions = (): IDropdownOption[] => [
+        { key: 0, text: intl.get("app.nodelay") },
+        { key: 1, text: intl.get("time.day", { d: 1 }) },
+        { key: 2, text: intl.get("time.day", { d: 2 }) },
+        { key: 3, text: intl.get("time.day", { d: 3 }) },
+        { key: 7, text: intl.get("time.week", { w: 1 }) },
+        { key: 14, text: intl.get("time.week", { w: 2 }) },
+        { key: 21, text: intl.get("time.week", { w: 3 }) },
+    ]
+    onFeedDelayChanged = (item: IDropdownOption) => {
+        this.props.setFeedDelay(item.key as number)
     }
 
     searchEngineOptions = (): IDropdownOption[] =>
@@ -195,6 +209,18 @@ class AppTab extends React.Component<AppTabProps, AppTabState> {
                 onChange={this.onThemeChange}
                 selectedKey={this.state.themeSettings}
             />
+
+            <Label>{intl.get("app.feedDelay")}</Label>
+            <Stack horizontal>
+                <Stack.Item>
+                    <Dropdown
+                        defaultSelectedKey={window.settings.getFeedDelay()}
+                        options={this.feedDelayOptions()}
+                        onChanged={this.onFeedDelayChanged}
+                        style={{ width: 200 }}
+                    />
+                </Stack.Item>
+            </Stack>
 
             <Label>{intl.get("app.fetchInterval")}</Label>
             <Stack horizontal>

--- a/src/containers/feed-container.tsx
+++ b/src/containers/feed-container.tsx
@@ -35,7 +35,9 @@ const makeMapStateToProps = () => {
         ],
         (sources, items, feed, viewType, filter, viewConfigs, currentItem) => ({
             feed: feed,
-            items: feed.iids.map(iid => items[iid]),
+            items: feed.iids
+                .map(iid => items[iid])
+                .filter(item => ((new Date()).getTime() - item.date.getTime()) > window.settings.getFeedDelay() * 86400000),
             sourceMap: sources,
             filter: filter,
             viewType: viewType,

--- a/src/containers/settings/app-container.tsx
+++ b/src/containers/settings/app-container.tsx
@@ -19,6 +19,9 @@ const mapDispatchToProps = (dispatch: AppDispatch) => ({
         window.settings.setFetchInterval(interval)
         dispatch(setupAutoFetch())
     },
+    setFeedDelay: (delay: number) => {
+        window.settings.setFeedDelay(delay)
+    },
     deleteArticles: async (days: number) => {
         dispatch(saveSettings())
         let date = new Date()

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -146,6 +146,14 @@ ipcMain.handle("set-fetch-interval", (_, interval: number) => {
     store.set(FETCH_INTEVAL_STORE_KEY, interval)
 })
 
+const FEED_DELAY_STORE_KEY = "feedDelay"
+ipcMain.on("get-feed-delay", event => {
+    event.returnValue = store.get(FEED_DELAY_STORE_KEY, 0)
+})
+ipcMain.handle("set-feed-delay", (_, interval: number) => {
+    store.set(FEED_DELAY_STORE_KEY, interval)
+})
+
 const SEARCH_ENGINE_STORE_KEY = "searchEngine"
 ipcMain.on("get-search-engine", event => {
     event.returnValue = store.get(SEARCH_ENGINE_STORE_KEY, SearchEngines.Google)

--- a/src/schema-types.ts
+++ b/src/schema-types.ts
@@ -93,6 +93,7 @@ export type SchemaTypes = {
     fontFamily: string
     menuOn: boolean
     fetchInterval: number
+    feedDelay: number
     searchEngine: SearchEngines
     serviceConfigs: ServiceConfigs
     filterType: number

--- a/src/scripts/i18n/en-US.json
+++ b/src/scripts/i18n/en-US.json
@@ -26,7 +26,8 @@
         "d": "d",
         "minute": "{m, plural, =1 {# minute} other {# minutes}}",
         "hour": "{h, plural, =1 {# hour} other {# hours}}",
-        "day": "{d, plural, =1 {# day} other {# days}}"
+        "day": "{d, plural, =1 {# day} other {# days}}",
+        "week": "{w, plural, =1 {# week} other {# weeks}}"
     },
     "log": {
         "empty": "No notifications",
@@ -237,6 +238,8 @@
         "setPac": "Set PAC",
         "pacHint": "For Socks proxies, it is recommended for PAC to return \"SOCKS5\" for proxy-side DNS. Turning off proxy requires restart.",
         "fetchInterval": "Automatic fetch interval",
-        "never": "Never"
+        "feedDelay": "Feed delay",
+        "never": "Never",
+        "nodelay": "No delay"
     }
 }


### PR DESCRIPTION
This feature is an intentional delay on the feed you're getting (if you look under the app settings, there's a new dropdown that implements this). Some people might want articles that are at least 3 days old, or something like that. My colleagues, in particular, prefer to get their news a week late. This commit allows that possibility and only shows articles of a minimum age for all sources.

I might modify this in the future to allow individual delays per source, which I think would be more appropriate. As for now, I'd like to request feedback on what I should improve in this commit that would allow you to accept it.