### PR TITLE
Fix duplicate RSS items when pubDate is missing

### DIFF
--- a/src/scripts/models/item.ts
+++ b/src/scripts/models/item.ts
@@ -41,7 +41,7 @@ export class RSSItem {
     notify: boolean
     serviceRef?: string
 
-    constructor(item: MyParserItem, source: RSSSource) {
+    constructor(item: MyParserItem, source: RSSSource, index: number = 0) {
         for (let field of ["title", "link", "creator"]) {
             const content = item[field]
             if (content && typeof content !== "string") delete item[field]
@@ -50,7 +50,14 @@ export class RSSItem {
         this.title = item.title || intl.get("article.untitled")
         this.link = item.link || ""
         this.fetchedDate = new Date()
-        this.date = new Date(item.isoDate ?? item.pubDate ?? this.fetchedDate)
+        const fallbackDate = item.isoDate ?? item.pubDate
+        if (fallbackDate) {
+            this.date = new Date(fallbackDate)
+        } else {
+            // for items without pubDate: put them at the bottom while preserving feed order
+            const offsetMs = (100 * 365 * 24 * 60 * 60 * 1000) + (index * 1000)
+            this.date = new Date(this.fetchedDate.getTime() - offsetMs)
+        }
         this.creator = item.creator
         this.hasRead = false
         this.starred = false

--- a/src/scripts/models/source.ts
+++ b/src/scripts/models/source.ts
@@ -69,9 +69,10 @@ export class RSSSource {
 
     private static async checkItem(
         source: RSSSource,
-        item: MyParserItem
+        item: MyParserItem,
+        index: number = 0
     ): Promise<RSSItem> {
-        let i = new RSSItem(item, source)
+        let i = new RSSItem(item, source, index)
         const predicate = i.link
             ? lf.op.and(
                 db.items.source.eq(i.source),
@@ -103,8 +104,8 @@ export class RSSSource {
     ): Promise<RSSItem[]> {
         return new Promise<RSSItem[]>((resolve, reject) => {
             let p = new Array<Promise<RSSItem>>()
-            for (let item of items) {
-                p.push(this.checkItem(source, item))
+            for (let i = 0; i < items.length; i++) {
+                p.push(this.checkItem(source, items[i], i))
             }
             Promise.all(p)
                 .then(values => {


### PR DESCRIPTION
## Issue

RSS feed items without a `pubDate` field are duplicated on every feed refresh.

**Example feed:** https://rsshub.app/anthropic/engineering
The article "Writing effective tools for agents — with agents" lacks a `pubDate`, causing it to appear at the top of the feed list after each refresh.

<img width="1130" height="1840" alt="fluent-reader-duplicate-items" src="https://github.com/user-attachments/assets/f3978ecb-079b-47db-9e2e-bc43f42f95d4" />

## Root Cause

When an RSS item has no `pubDate` or `isoDate`, the `RSSItem` constructor falls back to the current fetch time:

```typescript
this.date = new Date(item.isoDate ?? item.pubDate ?? this.fetchedDate)
```

The original deduplication logic used `(source, title, date)` as a composite key. Since the date changes on each fetch, the duplicate check fails and the same item gets inserted repeatedly.

## Solution

Use the item's link as the primary deduplication key instead of the date-based composite key:

- If link is present (vast majority of feeds): match on `(source, link)`
- If link is missing (rare edge case): fall back to `(source, title, date)`

Also fixed sorting for items without `pubDate`. Previously, these items appeared at the top of the feed (sorted as "newest" since they used the current fetch time). Now they appear at the bottom while preserving their feed order.

## Testing

Tested with multiple RSS feeds, including the problematic aforementioned one, as well as multiple others that worked fine initially (to confirm nothing got broken). No duplicates appear after multiple refreshes. Items without publication date appear on the bottom of the list.
