### PR TITLE
Added option to disable feed refresh on app start.

### DIFF
--- a/src/bridges/settings.ts
+++ b/src/bridges/settings.ts
@@ -89,6 +89,13 @@ const settingsBridge = {
         ipcRenderer.invoke("set-fetch-interval", interval)
     },
 
+    getRefreshOnStart: (): boolean => {
+        return ipcRenderer.sendSync("get-refresh-on-start")
+    },
+    setRefreshOnStart: (flag: boolean) => {
+        ipcRenderer.invoke("set-refresh-on-start", flag)
+    },
+
     getSearchEngine: (): SearchEngines => {
         return ipcRenderer.sendSync("get-search-engine")
     },

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -13,6 +13,7 @@ type NavProps = {
     search: () => void
     markAllRead: () => void
     fetch: () => void
+    stopFetch: () => void
     logs: () => void
     views: () => void
     settings: () => void
@@ -155,10 +156,18 @@ class Nav extends React.Component<NavProps, NavState> {
                 <span className="title">{this.props.state.title}</span>
                 <div className="btn-group" style={{ float: "right" }}>
                     <a
-                        className={"btn" + this.fetching()}
-                        onClick={this.fetch}
-                        title={intl.get("nav.refresh")}>
-                        <Icon iconName="Refresh" />
+                        className="btn"
+                        onClick={
+                            this.canFetch() ? this.fetch : this.props.stopFetch
+                        }
+                        title={
+                            this.canFetch()
+                                ? intl.get("nav.refresh")
+                                : intl.get("nav.stop")
+                        }>
+                        <Icon
+                            iconName={this.canFetch() ? "Refresh" : "Cancel"}
+                        />
                     </a>
                     <a
                         className="btn"

--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -3,7 +3,7 @@ import intl from "react-intl-universal"
 import { Icon } from "@fluentui/react/lib/Icon"
 import { AnimationClassNames } from "@fluentui/react/lib/Styling"
 import AboutTab from "./settings/about"
-import { Pivot, PivotItem, Spinner, FocusTrapZone } from "@fluentui/react"
+import { Pivot, PivotItem, Spinner, FocusTrapZone, DefaultButton } from "@fluentui/react"
 import SourcesTabContainer from "../containers/settings/sources-container"
 import GroupsTabContainer from "../containers/settings/groups-container"
 import AppTabContainer from "../containers/settings/app-container"
@@ -16,6 +16,7 @@ type SettingsProps = {
     blocked: boolean
     exitting: boolean
     close: () => void
+    stopFetch: () => void
 }
 
 class Settings extends React.Component<SettingsProps> {
@@ -68,6 +69,12 @@ class Settings extends React.Component<SettingsProps> {
                                 label={intl.get("settings.fetching")}
                                 tabIndex={0}
                             />
+                            <div style={{ marginTop: 12, textAlign: "center" }}>
+                                <DefaultButton
+                                    text="Stop"
+                                    onClick={this.props.stopFetch}
+                                />
+                            </div>
                         </FocusTrapZone>
                     )}
                     <Pivot>

--- a/src/components/settings/app.tsx
+++ b/src/components/settings/app.tsx
@@ -40,6 +40,7 @@ type AppTabState = {
     itemSize: string
     cacheSize: string
     deleteIndex: string
+    refreshOnStart: boolean
 }
 
 class AppTab extends React.Component<AppTabProps, AppTabState> {
@@ -52,6 +53,7 @@ class AppTab extends React.Component<AppTabProps, AppTabState> {
             itemSize: null,
             cacheSize: null,
             deleteIndex: null,
+            refreshOnStart: window.settings.getRefreshOnStart(),
         }
         this.getItemSize()
         this.getCacheSize()
@@ -156,6 +158,11 @@ class AppTab extends React.Component<AppTabProps, AppTabState> {
         })
     }
 
+    toggleRefreshOnStart = (_: any, checked: boolean) => {
+        window.settings.setRefreshOnStart(checked)
+        this.setState({ refreshOnStart: checked })
+    }
+
     handleInputChange = event => {
         const name: string = event.target.name
         // @ts-ignore
@@ -195,6 +202,18 @@ class AppTab extends React.Component<AppTabProps, AppTabState> {
                 onChange={this.onThemeChange}
                 selectedKey={this.state.themeSettings}
             />
+
+            <Stack horizontal verticalAlign="baseline">
+                <Stack.Item grow>
+                    <Label>{intl.get("app.refreshOnStart")}</Label>
+                </Stack.Item>
+                <Stack.Item>
+                    <Toggle
+                        checked={this.state.refreshOnStart}
+                        onChange={this.toggleRefreshOnStart}
+                    />
+                </Stack.Item>
+            </Stack>
 
             <Label>{intl.get("app.fetchInterval")}</Label>
             <Stack horizontal>

--- a/src/containers/nav-container.tsx
+++ b/src/containers/nav-container.tsx
@@ -2,7 +2,7 @@ import intl from "react-intl-universal"
 import { connect } from "react-redux"
 import { createSelector } from "reselect"
 import { RootState } from "../scripts/reducer"
-import { fetchItems, markAllRead } from "../scripts/models/item"
+import { fetchItems, markAllRead, stopFetchItems } from "../scripts/models/item"
 import {
     toggleMenu,
     toggleLogMenu,
@@ -25,9 +25,9 @@ const mapStateToProps = createSelector(
         itemShown: itemShown,
     })
 )
-
 const mapDispatchToProps = dispatch => ({
     fetch: () => dispatch(fetchItems()),
+    stopFetch: () => dispatch(stopFetchItems()),
     menu: () => dispatch(toggleMenu()),
     logs: () => dispatch(toggleLogMenu()),
     views: () => dispatch(openViewMenu()),

--- a/src/containers/settings-container.tsx
+++ b/src/containers/settings-container.tsx
@@ -2,6 +2,7 @@ import { connect } from "react-redux"
 import { createSelector } from "reselect"
 import { RootState } from "../scripts/reducer"
 import { exitSettings } from "../scripts/models/app"
+import { stopFetchItems } from "../scripts/models/item"
 import Settings from "../components/settings"
 
 const getApp = (state: RootState) => state.app
@@ -19,6 +20,7 @@ const mapStateToProps = createSelector([getApp], app => ({
 const mapDispatchToProps = dispatch => {
     return {
         close: () => dispatch(exitSettings()),
+        stopFetch: () => dispatch(stopFetchItems()),
     }
 }
 

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -146,6 +146,14 @@ ipcMain.handle("set-fetch-interval", (_, interval: number) => {
     store.set(FETCH_INTEVAL_STORE_KEY, interval)
 })
 
+const REFRESH_ON_START_STORE_KEY = "refreshOnStart"
+ipcMain.on("get-refresh-on-start", event => {
+    event.returnValue = store.get(REFRESH_ON_START_STORE_KEY, true)
+})
+ipcMain.handle("set-refresh-on-start", (_, flag: boolean) => {
+    store.set(REFRESH_ON_START_STORE_KEY, flag)
+})
+
 const SEARCH_ENGINE_STORE_KEY = "searchEngine"
 ipcMain.on("get-search-engine", event => {
     event.returnValue = store.get(SEARCH_ENGINE_STORE_KEY, SearchEngines.Google)

--- a/src/schema-types.ts
+++ b/src/schema-types.ts
@@ -98,4 +98,5 @@ export type SchemaTypes = {
     filterType: number
     listViewConfigs: ViewConfigs
     useNeDB: boolean
+    refreshOnStart: boolean
 }

--- a/src/scripts/i18n/en-US.json
+++ b/src/scripts/i18n/en-US.json
@@ -39,6 +39,7 @@
     "nav": {
         "menu": "Menu",
         "refresh": "Refresh",
+        "stop": "Stop refresh",
         "markAllRead": "Mark all as read",
         "notifications": "Notifications",
         "view": "View",
@@ -237,6 +238,7 @@
         "setPac": "Set PAC",
         "pacHint": "For Socks proxies, it is recommended for PAC to return \"SOCKS5\" for proxy-side DNS. Turning off proxy requires restart.",
         "fetchInterval": "Automatic fetch interval",
+        "refreshOnStart": "Refresh feeds on app start",
         "never": "Never"
     }
 }

--- a/src/scripts/models/app.ts
+++ b/src/scripts/models/app.ts
@@ -404,7 +404,11 @@ export function initApp(): AppThunk {
             .then(() => dispatch(initFeeds()))
             .then(async () => {
                 dispatch(selectAllArticles())
-                await dispatch(fetchItems())
+                if (window.settings.getRefreshOnStart()) {
+                    await dispatch(fetchItems())
+                } else {
+                    dispatch(setupAutoFetch())
+                }
             })
             .then(() => {
                 dispatch(updateFavicon())
@@ -555,17 +559,17 @@ export function appReducer(
                             action.items.length == 0
                                 ? state.logMenu
                                 : {
-                                      ...state.logMenu,
-                                      logs: [
-                                          ...state.logMenu.logs,
-                                          new AppLog(
-                                              AppLogType.Info,
-                                              intl.get("log.fetchSuccess", {
-                                                  count: action.items.length,
-                                              })
-                                          ),
-                                      ],
-                                  },
+                                    ...state.logMenu,
+                                    logs: [
+                                        ...state.logMenu.logs,
+                                        new AppLog(
+                                            AppLogType.Info,
+                                            intl.get("log.fetchSuccess", {
+                                                count: action.items.length,
+                                            })
+                                        ),
+                                    ],
+                                },
                     }
                 case ActionStatus.Intermediate:
                     return {


### PR DESCRIPTION
Now you can also terminate the refresh at any point with a new "Stop Refresh" nav element, and a "Stop" button when on the settings overlay.

# feat: Add "Refresh on Start" toggle and "Cancel Refresh" functionality

## Description
This PR introduces two key features to improve user control over feed updates: a new setting to toggle automatic refreshing on application startup, and the ability to cancel an ongoing refresh operation from both the navigation bar and the settings overlay. The motivation behind these changes is the blockage of UI during refresh, which can take a long time depending on the source library.

## Key Changes

### 1. Refresh on Start Toggle
- Added a new **"Refresh feeds on app start"** toggle in `Settings > Preferences`.
- Users can now opt-out of the immediate fetch upon launching the app. This is particularly useful for users with many feeds who want faster initial interactivity or are on metered connections.
- **Behavior:** If disabled, the app skips the initial fetch but still initializes the automatic background fetch timer (`setupAutoFetch`), ensuring feeds will eventually update based on the configured interval.

### 2. Cancel Refresh Functionality
- **Navigation Bar:**
    - The refresh button now changes to a **"Cancel"** (cross) icon while a fetch is in progress.
    - The rotation animation has been removed during fetching to indicate the button is interactive.
    - Clicking the button immediately terminates the fetch operation.
- **Settings Overlay:**
    - Added a **"Stop"** button to the "Updating sources, please wait..." blocking overlay.
    - This resolves a UX friction point where users could be locked out of the Settings page during a long-running or stuck fetch operation.
- **Underlying Logic:**
    - Implemented [stopFetchItems](cci:1://file:///e:/FluentReaderFork/fluent-reader-fork/src/scripts/models/item.ts:209:0-213:1) action.
    - Refactored [fetchItems](cci:1://file:///e:/FluentReaderFork/fluent-reader-fork/src/scripts/models/source.ts:114:4-117:5) to use `Promise.race`, allowing the fetch promise to be resolved early upon cancellation.
    - Partial results (items fetched before cancellation) are preserved and processed.

## Technical Details
- **Backend:** Added `REFRESH_ON_START_STORE_KEY` and IPC handlers to persist the new setting.
- **UI:**
    - Updated [Nav](cci:2://file:///e:/FluentReaderFork/fluent-reader-fork/src/components/nav.tsx:25:0-256:1) component to handle the cancel state and icon swapping.
    - Updated [Settings](cci:2://file:///e:/FluentReaderFork/fluent-reader-fork/src/components/settings.tsx:21:0-114:1) component to include a `DefaultButton` in the loading overlay.
- **Localization:** Added necessary strings to [en-US.json](cci:7://file:///e:/FluentReaderFork/fluent-reader-fork/src/scripts/i18n/en-US.json:0:0-0:0).

## Verification
- [x] **Refresh on Start:** Verified that disabling the toggle prevents the initial fetch on app launch, while enabling it restores the default behavior.
- [x] **Nav Cancel:** Verified that clicking the cross icon in the nav bar stops the fetch immediately.
- [x] **Settings Stop:** Verified that clicking "Stop" in the settings overlay dismisses the overlay and unblocks the UI.