### PR TITLE
fix: clamp unreadCount to non-negative on mark read/unread

### DIFF
--- a/src/scripts/models/source.ts
+++ b/src/scripts/models/source.ts
@@ -514,9 +514,11 @@ export function sourceReducer(
                 ...state,
                 [action.item.source]: {
                     ...state[action.item.source],
-                    unreadCount:
+                    unreadCount: Math.max(
+                        0,
                         state[action.item.source].unreadCount +
-                        (action.type === MARK_UNREAD ? 1 : -1),
+                            (action.type === MARK_UNREAD ? 1 : -1)
+                    ),
                 } as RSSSource,
             }
         case MARK_ALL_READ: {


### PR DESCRIPTION
## What

Prevent unread badges from going negative when marking items read.

## Why

MARK_READ decrements unreadCount without a floor. After desynced or repeated mark-read actions, the menu can show negative unread numbers.

Closes #511

## Changes

- Clamp unreadCount with Math.max(0, ...) in the source reducer for MARK_READ / MARK_UNREAD

## Verification

- Review reducer path for MARK_READ/MARK_UNREAD
- Unread badge display already hides zero; this prevents negative values from rendering
