### PR TITLE
fix: ignore keyboard shortcuts while typing in text fields

### DIFF
--- a/src/components/article.tsx
+++ b/src/components/article.tsx
@@ -213,6 +213,9 @@ class Article extends React.Component<ArticleProps, ArticleState> {
 
     keyDownHandler = (input: Electron.Input) => {
         if (input.type === "keyDown") {
+            // When the original webpage is loaded, letter shortcuts collide with
+            // form typing (e.g. email fields). Keep only Escape/arrows there.
+            const webpageMode = this.state.loadWebpage
             switch (input.key) {
                 case "Escape":
                     this.props.dismiss()
@@ -223,17 +226,21 @@ class Article extends React.Component<ArticleProps, ArticleState> {
                     break
                 case "l":
                 case "L":
+                    if (webpageMode) break
                     this.toggleWebpage()
                     break
                 case "w":
                 case "W":
+                    if (webpageMode) break
                     this.toggleFull()
                     break
                 case "H":
                 case "h":
+                    if (webpageMode) break
                     if (!input.meta) this.props.toggleHidden(this.props.item)
                     break
                 default:
+                    if (webpageMode && input.key.length === 1) break
                     const keyboardEvent = new KeyboardEvent("keydown", {
                         code: input.code,
                         key: input.key,

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -137,6 +137,16 @@ const Nav: React.FC = () => {
 
     const navShortcutsHandler = useCallback(
         (e: KeyboardEvent | IObjectWithKey) => {
+            const target = (e as KeyboardEvent).target as EventTarget | null
+            if (
+                target instanceof HTMLElement &&
+                (target.tagName === "INPUT" ||
+                    target.tagName === "TEXTAREA" ||
+                    target.tagName === "SELECT" ||
+                    target.isContentEditable)
+            ) {
+                return
+            }
             if (!state.settings.display) {
                 switch (e.key) {
                     case "F1":

--- a/src/scripts/models/item.ts
+++ b/src/scripts/models/item.ts
@@ -424,9 +424,21 @@ export function toggleHidden(item: RSSItem): AppThunk {
     }
 }
 
+function isEditableKeyboardTarget(target: EventTarget | null): boolean {
+    if (!(target instanceof HTMLElement)) return false
+    const tag = target.tagName
+    return (
+        tag === "INPUT" ||
+        tag === "TEXTAREA" ||
+        tag === "SELECT" ||
+        target.isContentEditable
+    )
+}
+
 export function itemShortcuts(item: RSSItem, e: KeyboardEvent): AppThunk {
     return dispatch => {
         if (e.metaKey) return
+        if (isEditableKeyboardTarget(e.target)) return
         switch (e.key) {
             case "m":
             case "M":


### PR DESCRIPTION
## What

Disable single-key app shortcuts when the user is typing in form fields or when the article webview is showing the original webpage.

## Why

Typing an email address (or any form input) could trigger shortcuts like m/b/s/h and close or mutate the article (issue #522).

Closes #522

## Changes

- itemShortcuts: ignore events whose target is INPUT/TEXTAREA/SELECT/contenteditable
- nav shortcuts: same editable-target guard
- article webview key handler: in webpage mode, keep only Escape/arrows and skip letter shortcuts

## Verification

- Type in search/settings inputs without triggering nav shortcuts
- Open article original webpage and type in a form without letter shortcuts firing
